### PR TITLE
Set date_default_timezone_set

### DIFF
--- a/assets/includes/bestbets_logger.php
+++ b/assets/includes/bestbets_logger.php
@@ -1,5 +1,7 @@
 <?php
 
+date_default_timezone_set('America/New_York');
+
 $logfile = '/srv/web/libcms/backup/bestbets_log.txt';
 
 if (isset($_GET['event'])) {


### PR DESCRIPTION
This should fix this issue reported by Derrek:

Appearing in the Apache logs on libcms..
`
[Wed Oct 26 06:15:49 2016] [error] [client 10.136.240.3] PHP Warning:  date(): It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected 'America/New_York' for 'EDT/-4.0/DST' instead in /srv/web/libcms/html/sites/all/modules/dul_bento/assets/includes/bestbets_logger.php on line 26, referer: https://library.duke.edu/find/all?Ntt=the+economist`
